### PR TITLE
22.08 5.15 and more (with fixups)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/net.jammr.jammr.json
+++ b/net.jammr.jammr.json
@@ -23,25 +23,6 @@
     ],
     "modules": [
         {
-            "name": "jack2",
-            "buildsystem": "simple",
-            "build-commands": [
-                "PREFIX=/ python3 ./waf configure",
-                "python3 ./waf build",
-                "python3 ./waf --destdir=/app install"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/jackaudio/jack2/releases/download/v1.9.14/v1.9.14.tar.gz",
-                    "sha256": "a20a32366780c0061fd58fbb5f09e514ea9b7ce6e53b080a44b11a558a83217c"
-                }
-            ],
-            "cleanup": [
-                "/bin"
-            ]
-        },
-        {
             "name": "portaudio",
             "config-opts": [
                 "--disable-static",

--- a/net.jammr.jammr.json
+++ b/net.jammr.jammr.json
@@ -6,8 +6,8 @@
     "command": "jammr",
     "finish-args": [
         "--share=ipc",
+        "--socket=fallback-x11",
         "--socket=wayland",
-        "--socket=x11",
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",

--- a/net.jammr.jammr.json
+++ b/net.jammr.jammr.json
@@ -30,8 +30,13 @@
             ],
             "sources": [
                 {
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 10597,
+                        "url-template": "http://files.portaudio.com/archives/pa_stable_v$version.tgz"
+                    },
                     "type": "archive",
-                    "url": "http://www.portaudio.com/archives/pa_stable_v190600_20161030.tgz",
+                    "url": "http://files.portaudio.com/archives/pa_stable_v190600_20161030.tgz",
                     "sha256": "f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513"
                 }
             ]
@@ -46,13 +51,17 @@
             ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://downloads.sourceforge.net/project/portmedia/portmidi/217/portmidi-src-217.zip",
-                    "sha256": "08e9a892bd80bdb1115213fb72dc29a7bf2ff108b378180586aa65f3cfd42e0f"
-                },
-                {
-                    "type": "patch",
-                    "path": "patches/portmidi/portmidi-no-java.patch"
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/PortMidi/portmidi/releases/latest",
+                        "tag-query": ".tag_name",
+                        "version-query": "$tag | sub(\"^v\"; \"\")",
+                        "timestamp-query": ".published_at"
+                    },
+                    "type": "git",
+                    "url": "https://github.com/PortMidi/portmidi.git",
+                    "tag": "v2.0.4",
+                    "commit": "b808babecdc5d05205467dab5c1006c5ac0fdfd4"
                 }
             ],
             "cleanup": [
@@ -69,16 +78,27 @@
                 "-DCMAKE_RUNTIME_OUTPUT_DIRECTORY=/app/bin",
                 "-DBUILD_TRANSLATIONS=off"
             ],
+            "modules": [
+                "shared-modules/libsecret/libsecret.json"
+            ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/frankosterfeld/qtkeychain/archive/v0.10.0.tar.gz",
-                    "sha256": "5f916cd97843de550467db32d2e10f218b904af5b21cfdfcc7c6425d7dfc3ec2"
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/frankosterfeld/qtkeychain/releases/latest",
+                        "tag-query": ".tag_name",
+                        "version-query": ".name",
+                        "timestamp-query": ".published_at"
+                    },
+                    "type": "git",
+                    "url": "https://github.com/frankosterfeld/qtkeychain.git",
+                    "tag": "v0.13.2",
+                    "commit": "c236f9241e37f1754879cf8726d59351a2b2b24a"
                 }
             ],
             "cleanup": [
                 "/bin",
-		"/mkspecs",
+                "/mkspecs",
                 "/lib/cmake"
             ]
         },

--- a/net.jammr.jammr.json
+++ b/net.jammr.jammr.json
@@ -1,7 +1,7 @@
 {
     "id": "net.jammr.jammr",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.14",
+    "runtime-version": "5.15-22.08",
     "sdk": "org.kde.Sdk",
     "command": "jammr",
     "finish-args": [

--- a/net.jammr.jammr.json
+++ b/net.jammr.jammr.json
@@ -11,7 +11,6 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
-        "--device=shm",
         "--filesystem=home"
     ],
     "cleanup": [

--- a/net.jammr.jammr.json
+++ b/net.jammr.jammr.json
@@ -105,15 +105,24 @@
         {
             "name": "jammr",
             "buildsystem": "qmake",
-            "config-opts": ["CONFIG+=jammr", "CONFIG+=qtclient"],
+            "config-opts": [
+                "CONFIG+=jammr",
+                "CONFIG+=qtclient"
+            ],
             "make-install-args": [
                 "INSTALL_ROOT=/app"
             ],
             "sources": [
                 {
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^(?:jammr-)?(\\d+\\.\\d+\\.\\d+)$",
+                        "version-scheme": "semantic"
+                    },
                     "type": "git",
                     "url": "https://github.com/wahjam/wahjam.git",
-                    "tag": "1.3.0"
+                    "tag": "1.3.1",
+                    "commit": "c1468239a261b8daf05c6c4d4ed199f2b2dc20a5"
                 }
             ]
         }


### PR DESCRIPTION
@wjt's #2 needs two small fixes to pass flatpak-builder-lint. I have removed socket=x11 since it was redundant with socket=fallback-x11. I have also removed device=shm because flatpak-builder-lint doesn't allow it together with device=all.

I have tested that audio works with ALSA.